### PR TITLE
Fix sign in with GitHub on mobile

### DIFF
--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -7,11 +7,16 @@
         <a
           class="my-2 flex justify-center space-x-5 lg:my-0 mx-2 btn py-4"
           href="#"
+          v-if="!signInLoading"
           @click.prevent="signInWithGitHub"
         >
           <img src="../assets/github.svg" alt="GitHub" />
           <p>Sign in with GitHub</p>
         </a>
+
+        <div class="flex justify-center">
+          <Spinner :loading="signInLoading" />
+        </div>
       </section>
     </main>
 
@@ -23,34 +28,55 @@
 import firebase from 'firebase';
 import Header from '@/components/Header.vue';
 import Footer from '@/components/Footer.vue';
+import Spinner from '@/components/Spinner.vue';
 
 export default {
   name: 'Details',
   components: {
     Header,
     Footer,
+    Spinner,
+  },
+  data() {
+    return {
+      signInLoading: false,
+    };
   },
   methods: {
     signInWithGitHub() {
       const provider = new firebase.auth.GithubAuthProvider();
       provider.addScope('repo');
 
+      firebase.auth().signInWithRedirect(provider);
+
+      window.localStorage.setItem('SignInWithRedirect', true);
+    },
+  },
+  created() {
+    const SignInWithRedirect = window.localStorage.getItem('SignInWithRedirect');
+
+    if (SignInWithRedirect) {
+      this.signInLoading = true;
+
       firebase
         .auth()
-        .signInWithPopup(provider)
+        .getRedirectResult()
         .then((result) => {
-          const token = result.credential.accessToken;
-          const { user } = result;
+          if (result.credential) {
+            const token = result.credential.accessToken;
+            const { user } = result;
 
-          window.localStorage.setItem('token', token);
-          window.localStorage.setItem('userId', user.uid);
+            window.localStorage.removeItem('SignInWithRedirect');
+            window.localStorage.setItem('token', token);
+            window.localStorage.setItem('userId', user.uid);
 
-          this.$router.push({ name: 'Dashboard' });
+            this.$router.push({ name: 'Dashboard' });
+          }
         })
         .catch(() => {
           // Error
         });
-    },
+    }
   },
 };
 </script>


### PR DESCRIPTION
- Use firebase `signInWithRedirect` GitHub sign-in method.
- Add spinner to sign-in page to give users a visual indication of sign-in operation in progress.